### PR TITLE
Improve error handling in ingredient loader

### DIFF
--- a/ingredients.html
+++ b/ingredients.html
@@ -247,10 +247,15 @@
         async function loadProductsIngredients() {
             try {
                 const response = await fetch('products.json');
+                if (!response.ok) {
+                    throw new Error(`HTTP error! status: ${response.status}`);
+                }
                 const products = await response.json();
                 displayProductsIngredients(products);
             } catch (error) {
                 console.error('Erreur lors du chargement des produits:', error);
+                const container = document.getElementById('products-ingredients');
+                container.innerHTML = '<div class="text-center text-gray-600"><p>Désolé, les produits ne peuvent pas être chargés pour le moment.</p></div>';
             }
         }
 


### PR DESCRIPTION
## Summary
- fail early if `products.json` fetch response isn't ok
- show a fallback message in `ingredients.html` when product data fails to load

## Testing
- `git diff --check`

------
https://chatgpt.com/codex/tasks/task_e_685f116b05748320a0ad255a01c40b7a